### PR TITLE
Toolkit-Ergänzungen: Positionierung, OParl, Offline-Kanäle, Code for Germany

### DIFF
--- a/01-verstehen/README.md
+++ b/01-verstehen/README.md
@@ -35,7 +35,7 @@ Das ist keine zumutbare Erwartung.
 
 ## Der Ansatz
 
-Der [Government Digital Service (GDS)](https://www.gov.uk/guidance/government-design-principles) ist die Digitalabteilung der britischen Regierung. Ihre Gestaltungsprinzipien für öffentliche Dienste gelten international als Maßstab. Prinzip #1 lautet: "Start with user needs." Nicht mit Verwaltungsstrukturen. Nicht mit Organigrammen. Mit den Fragen, die Bürger tatsächlich haben.
+Der [Government Digital Service (GDS)](https://www.gov.uk/guidance/government-design-principles) ist die Digitalabteilung der britischen Regierung. Ihre Gestaltungsprinzipien für öffentliche Dienste gelten international als Maßstab. Prinzip #1 lautet: „Start with user needs.“ Nicht mit Verwaltungsstrukturen. Nicht mit Organigrammen. Mit den Fragen, die Bürger tatsächlich haben.
 
 MeinBezirk organisiert Informationen nach drei Dimensionen:
 
@@ -46,6 +46,17 @@ MeinBezirk organisiert Informationen nach drei Dimensionen:
 Statt Bürger durch Verwaltungssysteme zu schicken, überbrückt KI die Lücke zwischen bürokratischen Quelldaten und verständlicher Information. Amtsdeutsch wird zusammengefasst. Relevanz wird nach Ort und Lebenslage gefiltert.
 
 Dieser Ansatz wird in den folgenden Phasen konkretisiert: von der Datenrecherche ([Phase 02](../02-daten-finden/)) bis zum Betrieb ([Phase 05](../05-betreiben/)).
+
+## MeinBezirk im Civic-Tech-Ökosystem
+
+MeinBezirk ist nicht das erste Projekt, das kommunale Transparenz verbessern will. Es besetzt aber eine spezifische Lücke. Die bestehende Landschaft lässt sich als Schichten verstehen:
+
+- **Offene Daten** ([GovData](https://www.govdata.de), kommunale Open-Data-Portale): Rohdaten maschinenlesbar bereitstellen. Die Grundlage, auf der alles aufbaut.
+- **Parlamentarische Accountability** ([Abgeordnetenwatch](https://www.abgeordnetenwatch.de)): Bürger können Abgeordnete direkt und öffentlich befragen. Macht Entscheider greifbar.
+- **Bürgerbeteiligung** ([CONSUL Democracy](https://consuldemocracy.org)): Bürger stimmen ab, reichen Vorschläge ein, gestalten Haushalte mit. Partizipation als Werkzeug.
+- **Informationszugang** (MeinBezirk): Entscheidungen verständlich und relevant aufbereiten. Die Übersetzungsschicht zwischen Verwaltungssystemen und Bürgern.
+
+Diese Schichten ergänzen sich. Wer mitentscheiden soll (CONSUL), muss erst verstehen, was entschieden wird (MeinBezirk). Wer Abgeordnete befragen will (Abgeordnetenwatch), braucht Kontext über die Entscheidungslage. MeinBezirk liefert diesen Kontext.
 
 ## Quellen
 

--- a/02-daten-finden/README.md
+++ b/02-daten-finden/README.md
@@ -55,7 +55,7 @@ Der Prozess hatte vier Schritte:
 
 2. **Relevanz filtern.** KI eingesetzt, um aus der Masse bürokratischer Dokumente die Einträge zu identifizieren, die Bürger tatsächlich betreffen. Nicht jede Drucksache ist relevant. Viele betreffen Verwaltungsinterna.
 
-3. **Sprache übersetzen.** Amtsdeutsch in verständliche Sprache umgewandelt. Eine Drucksache mit dem Titel "Große Anfrage zur Umsetzung der Maßnahmen gemäß Schulentwicklungsplan" wird zu: "Wie weit ist die Sanierung der Schulen im Bezirk?"
+3. **Sprache übersetzen.** Amtsdeutsch in verständliche Sprache umgewandelt. Eine Drucksache mit dem Titel „Große Anfrage zur Umsetzung der Maßnahmen gemäß Schulentwicklungsplan“ wird zu: „Wie weit ist die Sanierung der Schulen im Bezirk?“
 
 4. **Fakten verifizieren.** Jede KI-generierte Zusammenfassung gegen das Originaldokument geprüft. Zahlen, Daten, Beschlüsse mit der Quelle abgeglichen.
 
@@ -140,13 +140,15 @@ Deutschland hat kein einheitliches Ratsinformationssystem. Jede Kommune entschei
 
 In anderen Bundesländern sieht es ähnlich fragmentiert aus. Das ist die Realität, mit der jede Adaption umgehen muss.
 
-### OParl: Der offene Standard
+### OParl: Der Schlüssel zur Übertragbarkeit
 
-[OParl](https://oparl.org) ist eine standardisierte API-Spezifikation für den Zugriff auf Ratsinformationssysteme. Städte, deren System OParl unterstützt, bieten maschinenlesbaren Zugang zu ihren kommunalen Entscheidungsdaten.
+Die Fragmentierung der Ratsinformationssysteme (siehe Tabelle oben) ist das größte Hindernis für die Übertragbarkeit. Jede Stadt hat ein anderes System, jedes System hat eine andere Oberfläche, andere Datenstrukturen, andere Exportformate. Ohne Standard müsste jede MeinBezirk-Adaption von vorn anfangen.
 
-Das vereinfacht die Datenabfrage erheblich. Statt die Weboberfläche eines Ratsinformationssystems zu scrapen, kann man strukturierte Daten über eine API abrufen.
+[OParl](https://oparl.org) löst dieses Problem. OParl ist eine offene API-Spezifikation für Ratsinformationssysteme. Städte, deren System OParl unterstützt, bieten maschinenlesbaren Zugang zu ihren Entscheidungsdaten über eine einheitliche Schnittstelle. Drucksachen, Sitzungen, Tagesordnungen, Beschlüsse: alles in einem konsistenten JSON-Format, abrufbar ohne Scraping.
 
-Ob deine Stadt OParl unterstützt, prüfst du über die API unter [oparl.politik-bei-uns.de](https://oparl.politik-bei-uns.de/system).
+Für MeinBezirk-Adaptionen bedeutet das: Wenn deine Stadt OParl unterstützt, kannst du die Datenrecherche (Teil 1 dieses Kapitels) weitgehend automatisieren. Statt manuell durch ALLRIS oder SD.net zu klicken, rufst du die API ab. Das reduziert den Aufwand für den laufenden Betrieb erheblich.
+
+OParl-Unterstützung prüfen: [oparl.politik-bei-uns.de](https://oparl.politik-bei-uns.de/system). Dort siehst du, welche Städte bereits eine OParl-kompatible Schnittstelle anbieten.
 
 ### Politik bei uns
 
@@ -154,13 +156,13 @@ Ob deine Stadt OParl unterstützt, prüfst du über die API unter [oparl.politik
 
 ### Checkliste: Daten in deiner Stadt finden
 
-1. **Ratsinformationssystem suchen.** Suche "[Stadt] Ratsinformationssystem" in einer Suchmaschine. Die meisten Kommunen haben eins.
+1. **OParl-Unterstützung prüfen.** Das ist der wichtigste erste Schritt. Unter [oparl.politik-bei-uns.de](https://oparl.politik-bei-uns.de/system) nachsehen, ob deine Stadt eine OParl-kompatible Schnittstelle anbietet. Wenn ja, hast du strukturierten API-Zugang und kannst vieles automatisieren.
 
-2. **Open-Data-Portal prüfen.** Viele Städte betreiben eigene Open-Data-Portale mit strukturierten Datensätzen zu Verwaltung, Planung und Infrastruktur.
+2. **Ratsinformationssystem identifizieren.** Suche „[Stadt] Ratsinformationssystem“ in einer Suchmaschine. Die meisten Kommunen haben eins. Notiere, welches System im Einsatz ist (ALLRIS, SD.net, Session, etc.).
 
-3. **OParl-Unterstützung prüfen.** Unter [oparl.politik-bei-uns.de](https://oparl.politik-bei-uns.de/system) nachsehen, ob deine Stadt eine OParl-kompatible Schnittstelle anbietet.
+3. **Open-Data-Portal prüfen.** Viele Städte betreiben eigene Open-Data-Portale mit strukturierten Datensätzen zu Verwaltung, Planung und Infrastruktur.
 
-4. **Sitzungsprotokolle suchen.** BVV-, Stadtrat- oder Gemeinderatsprotokolle auf der Website deiner Stadt suchen. Oft sind sie unter "Politik" oder "Bürgerservice" verlinkt.
+4. **Sitzungsprotokolle suchen.** BVV-, Stadtrat- oder Gemeinderatsprotokolle auf der Website deiner Stadt suchen. Oft sind sie unter „Politik“ oder „Bürgerservice“ verlinkt.
 
 5. **Politik bei uns prüfen.** Unter [politik-bei-uns.de](https://politik-bei-uns.de) nachsehen, ob deine Stadt bereits abgedeckt ist.
 

--- a/05-betreiben/README.md
+++ b/05-betreiben/README.md
@@ -57,6 +57,18 @@ Was die Stadt davon hat. In ihrer Sprache.
 
 **Passt zur Digitalisierungsstrategie.** OZG, Registermodernisierung, digitale Verwaltung — MeinBezirk passt in bestehende Strategien. Es ist kein Fremdkörper. Es ist eine logische Ergänzung.
 
+## Die letzte Meile ist analog
+
+Digitale Plattformen erreichen bestimmte Menschen nicht. Ältere Bewohner, die kein Smartphone nutzen. Menschen ohne stabilen Internetzugang. Menschen, die der Technik misstrauen. Wenn MeinBezirk Transparenz für alle schaffen soll, braucht es analoge Begleitkanäle.
+
+Konkrete Möglichkeiten:
+
+- **Aushänge in Stadtteilbüros und Bürgerämtern.** Ein monatlicher A4-Einseiter mit den wichtigsten Entscheidungen. QR-Code verweist auf die digitale Version für alle, die mehr wissen wollen.
+- **Gedruckte Zusammenfassungen.** Quartalsweise, verteilt über lokale Vereine, Seniorentreffs, Bibliotheken.
+- **Kooperationen mit lokalen Organisationen.** Migrantenvereine, Nachbarschaftszentren, Kirchengemeinden: Sie erreichen Menschen, die keine städtische Website besuchen.
+
+Der Aufwand dafür ist gering, wenn die digitale Aufbereitung bereits steht. Ein PDF-Export der aktuellen Karten, formatiert für Druck. Die Technik ist das Rückgrat. Aber die letzte Meile zum Bürger ist oft ein Blatt Papier an der Pinnwand im Bürgeramt.
+
 ## Aufwand und Kosten
 
 Ehrliche Einschätzung. Nicht werblich.

--- a/05-betreiben/README.md
+++ b/05-betreiben/README.md
@@ -59,7 +59,7 @@ Was die Stadt davon hat. In ihrer Sprache.
 
 ## Die letzte Meile ist analog
 
-Digitale Plattformen erreichen bestimmte Menschen nicht. Ältere Bewohner, die kein Smartphone nutzen. Menschen ohne stabilen Internetzugang. Menschen, die der Technik misstrauen. Wenn MeinBezirk Transparenz für alle schaffen soll, braucht es analoge Begleitkanäle.
+Digitale Plattformen erreichen bestimmte Menschen nicht. Ältere Bewohner ohne Smartphone oder stabilen Internetzugang. Menschen, die der Technik misstrauen. Wenn MeinBezirk Transparenz für alle schaffen soll, braucht es analoge Begleitkanäle.
 
 Konkrete Möglichkeiten:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,14 @@ Adapting MeinBezirk for another German city:
 
 Especially valuable: documenting which Ratsinformationssystem your city uses and how to access its data. Every city handles this differently. That documentation helps everyone.
 
+## Für deutsche Civic-Tech-Communities
+
+Du bist Teil eines [Code for Germany](https://codefor.de) Labs oder einer lokalen Civic-Tech-Gruppe? Dann bist du die Zielgruppe dieses Toolkits. Die OK Labs kennen die Datenlandschaft ihrer Stadt, haben Kontakte in die Verwaltung und wissen, welche Ratsinformationssysteme lokal im Einsatz sind.
+
+Was besonders hilft: Dokumentiere, wie die Datenrecherche in deiner Stadt funktioniert hat. Welches System wird genutzt? Wo liegen die Hürden? Was fehlt? Diese Erfahrungsberichte machen das Toolkit für die nächste Stadt brauchbarer.
+
+Kontakt zu den Labs: [codefor.de](https://codefor.de). Die [Open Knowledge Foundation Deutschland](https://okfn.de) koordiniert das Netzwerk.
+
 ## Contributing from another country
 
 The methodology is transferable. The data landscape will be different.


### PR DESCRIPTION
## Summary

Vier Ergänzungen zum Toolkit-Content, basierend auf einer Recherche zu vergleichbaren Civic-Tech-Projekten (CONSUL, Abgeordnetenwatch, Localcities, Code for Germany):

- **CONTRIBUTING.md:** Code for Germany / OK Labs als Zielgruppe für deutsche Adaptionen (Closes #5)
- **01-verstehen:** MeinBezirk im Civic-Tech-Ökosystem positioniert (GovData → Abgeordnetenwatch → CONSUL → MeinBezirk als Schichten) (Closes #6)
- **02-daten-finden:** OParl als Schlüssel zur Übertragbarkeit stärker betont, Checkliste umgestellt (OParl als erster Prüfpunkt) (Closes #7)
- **05-betreiben:** Abschnitt zu Offline-Kanälen ergänzt (Aushänge, gedruckte Zusammenfassungen, lokale Kooperationen) (Closes #8)

Alle Änderungen sind reine Textergänzungen in bestehenden Markdown-Dateien, keine strukturellen Änderungen.

## Hintergrund

Recherche-Briefing mit den Details wurde separat geschickt.